### PR TITLE
Unset required rule and remove required asterisk

### DIFF
--- a/multisite.php
+++ b/multisite.php
@@ -470,4 +470,6 @@ function _multisite_get_domain_group($permission = 1) {
         $form->setDefaults($defaults);
       }
     }
+    unset($form->_required[2]);
+    unset($form->_rules['parents']);
   }


### PR DESCRIPTION
from parents field in edit group field for 4.6 and 4.5 via hook_buildForm

I have tested on AUG ubox on 4.6 and 4.4 and it seems to do sensible things when editing groups and also when adding new groups
