### PR TITLE
remove undefined var; ensure case in test;

### DIFF
--- a/multisite.php
+++ b/multisite.php
@@ -226,7 +226,7 @@ function multisite_civicrm_selectWhereClause($entity, &$clauses) {
   if (!$isEnabled || !$groupID) {
     return;
   }
-  if (!CRM_Core_Permission::check('list all groups in domain') && !_multisite_add_permissions($type)) {
+  if (!CRM_Core_Permission::check('list all groups in domain') && !_multisite_add_permissions(NULL)) {
     return;
   }
   $currentGroups = _multisite_get_all_child_groups($groupID, FALSE);
@@ -495,7 +495,7 @@ function _multisite_add_permissions($type) {
     // & default to applying this to all
     return TRUE;
   }
-  if ($type == 'group') {
+  if (strtolower($type) == 'group') {
     // @fixme only handling we have for this at the moment
     return TRUE;
   }


### PR DESCRIPTION
This is not really a fix... it resolves the warning about $type not being defined.
I tried substituting $entity, which I think is conceptually correct, but this changed the behaviour in our use-case. Using NULL preserves the status quo and quietes the warning.

I think, but didn't confirm that our case would pass 'group' in $entity, triggering the case that is marked as not implemented which is further reason I'm leaving it at a half-hearted fix.