### PR TITLE
Implement domain specific permissions for GroupContact.delete API cal…

### DIFF
--- a/multisite.php
+++ b/multisite.php
@@ -613,6 +613,11 @@ function multisite_civicrm_alterAPIPermissions($entity, $action, &$params, &$per
       'access CiviCRM',
       'edit all contacts in domain',
     );
+
+    $permissions['group_contact']['delete'] = array(
+      'access CiviCRM',
+      'edit all contacts in domain',
+    );
   }
 }
 


### PR DESCRIPTION
…ls so that users with edit all contacts in domain can remove contacts from groups via the contact summary groups tab

inspired in part by dev/core#1163 and some org specific issues this seems to be the most accurate thing to do. Thoughts @eileenmcnaughton @nganivet 