### PR TITLE
Implement hook alterEntityRef parameters to ensure current behaviour …

### DIFF
--- a/multisite.php
+++ b/multisite.php
@@ -641,3 +641,22 @@ function multisite_civicrm_apiWrappers(&$wrappers, $apiRequest) {
     $wrappers[] = new CRM_Multisite_MailingWrapper();
   }
 }
+
+/**
+ * Implements hook_civicrm_alterEntityRefParams().
+ *
+ * Alters Entity reference api params for MembershipType to ignore any domain_id filter
+ * So that the current behaviour continues
+ */
+function multisite_civicrm_alterEntityRefParams(&$props = [], $formName) {
+  if ($props['entity'] = 'MembershipType') {
+    if (!empty($props['api'])) {
+      if (!empty($props['api']['params'])) {
+        $props['api']['params']['domain_id'] = NULL;
+      }
+    }
+    else {
+      $props['api'] = ['params' => ['domain_id' => NULL]];
+    }
+  }
+}

--- a/multisite.php
+++ b/multisite.php
@@ -654,6 +654,9 @@ function multisite_civicrm_alterEntityRefParams(&$props = [], $formName) {
       if (!empty($props['api']['params'])) {
         $props['api']['params']['domain_id'] = NULL;
       }
+      else {
+        $props['api']['params'] = ['domain_id' => NULL]];
+      }
     }
     else {
       $props['api'] = ['params' => ['domain_id' => NULL]];


### PR DESCRIPTION
…remains after #15120

@eileenmcnaughton @nganivet i can only think of in advanced and find member searches were we find it especially useful to be able to search across all membership types regardless of domain. This locks in that behaviour when using the multisite extension